### PR TITLE
Fix for path_mapping config setting not loading

### DIFF
--- a/main.py
+++ b/main.py
@@ -199,6 +199,8 @@ class XdebugSessionStartCommand(sublime_plugin.WindowCommand):
     """
     def run(self, launch_browser=False, restart=False):
         # Define new session with DBGp protocol
+        # Get the path mapping now before we run into problems with the async thread
+        S.PATH_MAPPING = S.get_config_value('path_mapping')
         S.SESSION = protocol.Protocol()
         S.SESSION_BUSY = False
         S.BREAKPOINT_ROW = None

--- a/xdebug/util.py
+++ b/xdebug/util.py
@@ -56,7 +56,7 @@ def get_real_path(uri, server=False):
     if not drive_pattern.match(uri) and not os.path.isabs(uri):
         uri = os.path.normpath('/' + uri)
 
-    path_mapping = S.get_config_value('path_mapping')
+    path_mapping = S.PATH_MAPPING
     if isinstance(path_mapping, dict):
         # Go through path mappings
         for server_path, local_path in path_mapping.items():


### PR DESCRIPTION
Load the path_mapping at the start of debugging to eliminate problems with the async thread.

This is in reference to the issue discussed here:
https://github.com/martomo/SublimeTextXdebug/issues/39

 I don't know much python so the code might need tweaking.
