### PR TITLE
Another Fix for path_mapping config not loading

### DIFF
--- a/xdebug/session.py
+++ b/xdebug/session.py
@@ -127,10 +127,10 @@ class SocketHandler(threading.Thread):
                 self.evaluate(self.get_option('expression'))
             # Execute
             elif self.action == ACTION_EXECUTE:
-                self.execute(self.get_option('command'))
+                self.timeout(lambda: self.execute(self.get_option('command')))
             # Init
             elif self.action == ACTION_INIT:
-                self.init()
+                self.timeout(lambda: self.init())
             # Remove breakpoint
             elif self.action == ACTION_REMOVE_BREAKPOINT:
                 self.remove_breakpoint(self.get_option('breakpoint_id'))


### PR DESCRIPTION
Run the functions that access the config in the main thread by using the
self.timeout method built into the session.

I was looking into making the settings methods do the same thing, but I was unsure of how to return a value to a side thread from a method that is run in the main thread.

I know there is already another solution to this problem, but I was
curious if making the access to the configuration run on the main thread
had any benefits over storing the path_mapping beforehand.
