### PR TITLE
Modify drive_pattern regex to recognize UNC paths (leading "\\").

### DIFF
--- a/xdebug/util.py
+++ b/xdebug/util.py
@@ -45,7 +45,7 @@ def get_real_path(uri, server=False):
     try:
         # scheme:///path/file => scheme, /path/file
         # scheme:///C:/path/file => scheme, C:/path/file
-        transport, filename = uri.split(':///', 1) 
+        transport, filename = uri.split(':///', 1)
     except:
         filename = uri
 


### PR DESCRIPTION
This fixes issue #118 -- do you foresee any unwanted side effects?

I think technically it's unnecessary to include the `^` (and stemming from that the parens) in the regex if you only end up calling `match()` on it (?), but I left it and added the parens.

There's also a commit here that eliminates some trailing whitespace that was already present.
