### PR TITLE
Use custom region scopes for gutter items

### DIFF
--- a/xdebug/settings.py
+++ b/xdebug/settings.py
@@ -51,8 +51,8 @@ KEY_DEBUG = "debug"
 REGION_KEY_BREAKPOINT = 'xdebug_breakpoint'
 REGION_KEY_CURRENT = 'xdebug_current'
 REGION_KEY_DISABLED = 'xdebug_disabled'
-REGION_SCOPE_BREAKPOINT = 'comment.line.settings'
-REGION_SCOPE_CURRENT = 'string.quoted.settings'
+REGION_SCOPE_BREAKPOINT = 'xdebug.gutter.breakpoint'
+REGION_SCOPE_CURRENT    = 'xdebug.gutter.current'
 
 # Window layout for debugging output
 LAYOUT_DEBUG = {


### PR DESCRIPTION
The `Xdebug.tmLanguage` file defines these scopes:

```
xdebug.output.context.object
xdebug.output.context.property
xdebug.output.context.unknown
xdebug.output.context.trimmed
xdebug.output.stack.entry
xdebug.output.stack.exception
xdebug.output.breakpoint.file
xdebug.output.breakpoint.line
xdebug.output.watch.entry
```

These are useful for applying syntax highlighting to the Xdebug output.

Similarly, it'd be useful to have custom scopes for the items in the gutter, so that custom highlighting can be applied to them.
