### PR TITLE
Improve rendering of context variable trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This fork does one thing only: it tries to render context variable trees in a (hopefully) easier to read way, somewhat like the Xdebug client in PhpStorm does it.
+
 # SublimeTextXdebug
 Xdebug debugger client integration for Sublime Text.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-This fork does one thing only: it tries to render context variable trees in a (hopefully) easier to read way, somewhat like the Xdebug client in PhpStorm does it.
+This fork does one thing only: it tries to render context variable trees in a (hopefully) easier to read way, somewhat like the Xdebug client in PhpStorm does it. This is what it looks like:
+
+![SublimeTextXdebug](http://i.imgur.com/dapUcQa.png?1)
 
 # SublimeTextXdebug
 Xdebug debugger client integration for Sublime Text.

--- a/xdebug/view.py
+++ b/xdebug/view.py
@@ -85,7 +85,7 @@ def generate_breakpoint_output():
     return values
 
 
-def generate_context_output(context, indent=0):
+def generate_context_output(context, indent=0, parent=''):
     """
     Generate readable context from dictionary with context data.
 
@@ -100,6 +100,11 @@ def generate_context_output(context, indent=0):
     for variable in context.values():
         has_children = False
         property_text = ''
+        if variable['name']:
+            full_name = variable['name']
+            if parent:
+                local_parent = parent
+                variable['name'] = full_name.replace(local_parent, "")
         # Set indentation
         for i in range(indent): property_text += '\t'
         # Property with value
@@ -131,7 +136,7 @@ def generate_context_output(context, indent=0):
         # Append property children to output
         if has_children:
             # Get children for property (no need to convert, already unicode)
-            values += generate_context_output(variable['children'], indent+1)
+            values += generate_context_output(variable['children'], indent+1, full_name)
             # Use ellipsis to indicate that results have been truncated
             limited = False
             if isinstance(variable['numchildren'], int) or H.is_digit(variable['numchildren']):


### PR DESCRIPTION
Hey there,

this change does one thing only: it renders the context variable trees in a (hopefully) slightly easier to read way. 

Of course, the changes to the Readme should be disregarded!

Thanks for your consideration!
janstoeckler
