### PR TITLE
Fix bug: Bad call to watch_expression() in SocketHandler.execute()

### DIFF
--- a/xdebug/session.py
+++ b/xdebug/session.py
@@ -201,7 +201,6 @@ class SocketHandler(threading.Thread):
         S.BREAKPOINT_EXCEPTION = None
         S.BREAKPOINT_ROW = None
         S.CONTEXT_DATA.clear()
-        self.watch_expression()
         # Set debug layout
         self.run_command('xdebug_layout')
 


### PR DESCRIPTION
A command (such as `run`) is sent to the debugger engine on line 197:

    S.SESSION.send(command)

The engine could respond with `status="stopping"`.  From the [DBGP docs](http://xdebug.org/docs-dbgp.php#initiating-a-debugging-session):

> This 'stopping' state is entered after all execution is complete.  For most debugger engine implementations, only a 'stop' command can be accepted at this point

`watch_expression()` sends an `eval` command to the engine for each watch expression.  If the engine's state is `stopping`, then it'll probably respond to the `eval` commands with:

    error code 5: command is not available

So it's wrong to call `watch_expression()` here without checking the engine's state.

`watch_expression()` should only be called if the engine's state is `break`, and in fact the code does this on line 249.