### PR TITLE
base64 properties should be decoded with proper encodings

### DIFF
--- a/xdebug/helper/helper.py
+++ b/xdebug/helper/helper.py
@@ -36,9 +36,9 @@ def data_write(data):
 	# Convert string to bytes
 	return bytes(data, 'utf8')
 
-def base64_decode(data):
+def base64_decode(data, charset, errorMode = 'strict'):
 	# Base64 returns decoded byte string, decode to convert to UTF8 string
-	return base64.b64decode(data).decode('utf8')
+	return base64.b64decode(data).decode(charset)
 
 def base64_encode(data):
 	# Base64 needs ascii input to encode, which returns Base64 byte string, decode to convert to UTF8 string

--- a/xdebug/view.py
+++ b/xdebug/view.py
@@ -317,10 +317,20 @@ def get_response_properties(response, default_key=None):
                 property_value = child.text
                 # Try to decode property value when encoded with base64
                 if property_encoding is not None and property_encoding == 'base64':
+                    view = sublime.active_window().active_view()
+                    match = re.search(r'\((.*?)\)', view.encoding())
+                    if match:
+                        encoding_name = match.group(1)
+                        encoding_name = encoding_name.replace(' ', '-').lower()
                     try:
-                        property_value = H.base64_decode(child.text)
-                    except:
-                        pass
+                        property_value = H.base64_decode(child.text, 'utf8')
+                    except UnicodeDecodeError, LookupError:
+                        if encoding_name == 'Undefined':
+                            raise
+                        else:
+                            property_value = H.base64_decode(child.text, encoding_name)
+                    except UnicodeDecodeError, LookupError:
+                        property_value = H.base64_decode(child.text, 'utf8', 'replace')
 
             if property_name is not None and len(property_name) > 0:
                 property_key = property_name


### PR DESCRIPTION
In current version strings with encoded other than utf8 are sometimes cant properly decoded.

Sometimes it gives UnicodeDecodeError

I'm not a python guy but it seems this commit will fix this issue.