### PR TITLE
base64 values should be decoded with proper encodings

### DIFF
--- a/xdebug/helper/helper.py
+++ b/xdebug/helper/helper.py
@@ -30,19 +30,19 @@ def dictionary_values(dictionary):
 
 def data_read(data):
 	# Convert bytes to string
-	return data.decode('utf8')
+	return data.decode('utf8', 'replace')
 
 def data_write(data):
 	# Convert string to bytes
-	return bytes(data, 'utf8')
+	return bytes(data, 'utf8', 'replace')
 
-def base64_decode(data):
+def base64_decode(data, charset, errorMode = 'strict'):
 	# Base64 returns decoded byte string, decode to convert to UTF8 string
-	return base64.b64decode(data).decode('utf8')
+	return base64.b64decode(data).decode(charset, errorMode)
 
 def base64_encode(data):
 	# Base64 needs ascii input to encode, which returns Base64 byte string, decode to convert to UTF8 string
-	return base64.b64encode(data.encode('ascii')).decode('utf8')
+	return base64.b64encode(data.encode('ascii')).decode('utf8', 'replace')
 
 def unicode_chr(code):
 	return chr(code)

--- a/xdebug/view.py
+++ b/xdebug/view.py
@@ -317,10 +317,20 @@ def get_response_properties(response, default_key=None):
                 property_value = child.text
                 # Try to decode property value when encoded with base64
                 if property_encoding is not None and property_encoding == 'base64':
+                    view = sublime.active_window().active_view()
+                    match = re.search(r'\((.*?)\)', view.encoding())
+                    if match:
+                        encoding_name = match.group(1)
+                        encoding_name = encoding_name.replace(' ', '-').lower()
                     try:
-                        property_value = H.base64_decode(child.text)
-                    except:
-                        pass
+                        property_value = H.base64_decode(child.text, 'utf8')
+                    except (UnicodeDecodeError, LookupError):
+                        if encoding_name == 'Undefined':
+                            raise
+                        else:
+                            property_value = H.base64_decode(child.text, encoding_name)
+                    except (UnicodeDecodeError, LookupError):
+                        property_value = H.base64_decode(child.text, 'utf8', 'replace')
 
             if property_name is not None and len(property_name) > 0:
                 property_key = property_name


### PR DESCRIPTION
base64 values should be decoded with proper encodings

base64 properties was always been decoded with base64.b64decode(data).decode('utf8')

which is a strict mode. It throws UnicodeDecodeError exception when the property value is not UTF-8

