### PR TITLE
The bind is associated to localhost only. If the host is running with…

### DIFF
--- a/xdebug/protocol.py
+++ b/xdebug/protocol.py
@@ -241,7 +241,7 @@ class Protocol(object):
             try:
                 server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 server.settimeout(1)
-                server.bind(('', self.port))
+                server.bind(('0.0.0.0', self.port))
                 server.listen(1)
                 self.listening = True
                 self.socket = None


### PR DESCRIPTION
… multiple network cards and the php is running into another machine, this may derive into connection problems. To solve them, the bind must be made with 0.0.0.0 instead. This will bind the port into all available IPs of the host