### PR TITLE
Fixed urllib.parse import for Python 3.3.6 (Sublime build 3142).

### DIFF
--- a/xdebug/helper/helper.py
+++ b/xdebug/helper/helper.py
@@ -7,17 +7,17 @@ Helper module for Python version 3.0 and above
 """
 
 import base64
-import urllib.parse
+from urllib.parse import unquote, quote
 from collections import OrderedDict
 
 def modulename():
 	return "Helper module for Python version 3.0 and above"
 
 def url_decode(uri):
-	return urllib.parse.unquote(uri)
+	return unquote(uri)
 
 def url_encode(uri):
-	return urllib.parse.quote(uri)
+	return quote(uri)
 
 def new_dictionary():
 	return OrderedDict()


### PR DESCRIPTION
Fixes issue #163 (AttributeError: 'module' object has no attribute 'parse').
Totally untested for python 3.0, might need to be split to a separate file.