### PR TITLE
Added host address configuration (default to '', the current value).

### DIFF
--- a/Xdebug.sublime-settings
+++ b/Xdebug.sublime-settings
@@ -25,6 +25,11 @@
     // It is merely used when launching the default web browser with the configured URL.
     "ide_key": "sublime.xdebug",
 
+    // Which host address Sublime Text should listen
+    // to connect with debugger engine.
+    // e.g. 0.0.0.0 or localhost
+    "host": "",
+
     // Which port number Sublime Text should listen
     // to connect with debugger engine.
     "port": 9000,

--- a/xdebug/protocol.py
+++ b/xdebug/protocol.py
@@ -72,6 +72,8 @@ class Protocol(object):
     read_size = 1024
 
     def __init__(self):
+        # Set host address to listen for response
+        self.host = get_value(S.KEY_HOST, S.DEFAULT_HOST)
         # Set port number to listen for response
         self.port = get_value(S.KEY_PORT, S.DEFAULT_PORT)
         self.clear()
@@ -241,7 +243,7 @@ class Protocol(object):
             try:
                 server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 server.settimeout(1)
-                server.bind(('', self.port))
+                server.bind((self.host, self.port))
                 server.listen(1)
                 self.listening = True
                 self.socket = None

--- a/xdebug/settings.py
+++ b/xdebug/settings.py
@@ -1,3 +1,4 @@
+DEFAULT_HOST = ''
 DEFAULT_PORT = 9000
 DEFAULT_IDE_KEY = 'sublime.xdebug'
 
@@ -15,6 +16,7 @@ KEY_XDEBUG = 'xdebug'
 KEY_PATH_MAPPING = "path_mapping"
 KEY_URL = "url"
 KEY_IDE_KEY = "ide_key"
+KEY_HOST = "host"
 KEY_PORT = "port"
 KEY_SUPER_GLOBALS = "super_globals"
 KEY_MAX_CHILDREN = "max_children"
@@ -91,6 +93,7 @@ CONFIG_KEYS = [
 	KEY_PATH_MAPPING,
 	KEY_URL,
 	KEY_IDE_KEY,
+	KEY_HOST,
 	KEY_PORT,
 	KEY_SUPER_GLOBALS,
 	KEY_MAX_CHILDREN,


### PR DESCRIPTION
So users can decide to listen to `127.0.0.1` (`localhost`) or `0.0.0.0`. I did not yet test with ipv6. In my opinion this is a cleaner fix than the PR https://github.com/martomo/SublimeTextXdebug/pull/173 to always listen to `0.0.0.0`.