### PR TITLE
Fix quote parsing on XML

### DIFF
--- a/xdebug/protocol.py
+++ b/xdebug/protocol.py
@@ -133,6 +133,8 @@ class Protocol(object):
                     # Following are not needed to be converted for XML
                     if text[1:-1] == 'amp' or text[1:-1] == 'gt' or text[1:-1] == 'lt':
                         pass
+                    elif text[1:-1] == 'quot':
+                        text = "'"
                     else:
                         text = H.unicode_chr(name2codepoint[text[1:-1]])
                 except KeyError:


### PR DESCRIPTION
This fix an error while parsing quotes in XML returned from Xdebug server