### PR TITLE
Mapping ordered list and fix for special chars bug in array keys

### DIFF
--- a/xdebug/elementtree/ElementTree.py
+++ b/xdebug/elementtree/ElementTree.py
@@ -803,6 +803,8 @@ def _escape_cdata(text, encoding=None, replace=string.replace):
             except UnicodeError:
                 return _encode_entity(text)
         text = replace(text, "&", "&amp;")
+        text = replace(text, "'", "&apos;")
+        text = replace(text, "\"", "&quot;")
         text = replace(text, "<", "&lt;")
         text = replace(text, ">", "&gt;")
         return text
@@ -818,7 +820,7 @@ def _escape_attrib(text, encoding=None, replace=string.replace):
             except UnicodeError:
                 return _encode_entity(text)
         text = replace(text, "&", "&amp;")
-        text = replace(text, "'", "&apos;") # FIXME: overkill
+        text = replace(text, "'", "&apos;")
         text = replace(text, "\"", "&quot;")
         text = replace(text, "<", "&lt;")
         text = replace(text, ">", "&gt;")

--- a/xdebug/helper/helper.py
+++ b/xdebug/helper/helper.py
@@ -37,22 +37,22 @@ def dictionary_values(dictionary):
 
 def data_read(data):
     # Convert bytes to string
-    return data.decode('utf8')
+    return data.decode('utf8', 'replace')
 
 
 def data_write(data):
     # Convert string to bytes
-    return bytes(data, 'utf8')
+    return bytes(data, 'utf8', 'replace')
 
 
 def base64_decode(data):
     # Base64 returns decoded byte string, decode to convert to UTF8 string
-    return base64.b64decode(data).decode('utf8')
+    return base64.b64decode(data).decode('utf8', 'replace')
 
 
 def base64_encode(data):
     # Base64 needs ascii input to encode, which returns Base64 byte string, decode to convert to UTF8 string
-    return base64.b64encode(data.encode('ascii')).decode('utf8')
+    return base64.b64encode(data.encode('ascii')).decode('utf8', 'replace')
 
 
 def unicode_chr(code):

--- a/xdebug/protocol.py
+++ b/xdebug/protocol.py
@@ -165,10 +165,15 @@ class Protocol(object):
         # Verify length of response data
         length = self.read_until_null()
         message = self.read_until_null()
-        if int(length) == len(message):
-            return message
-        else:
-            raise ProtocolException('Length mismatch encountered while reading the Xdebug message')
+
+        return message
+        
+        # Verification disabled due to incorrect length bug
+
+        # if int(length) == len(message):
+        #     return message
+        # else:
+        #     raise ProtocolException('Length mismatch encountered while reading the Xdebug message')
 
     def read(self, return_string=False):
         """

--- a/xdebug/util.py
+++ b/xdebug/util.py
@@ -59,23 +59,27 @@ def get_real_path(uri, server=False):
     if not drive_pattern.match(uri) and not os.path.isabs(uri):
         uri = os.path.normpath('/' + uri)
 
+    mapped_paths = []
     path_mapping = get_value(S.KEY_PATH_MAPPING)
-    if isinstance(path_mapping, dict):
-        # Go through path mappings
-        for server_path, local_path in path_mapping.items():
-            server_path = os.path.normpath(server_path)
-            local_path = os.path.normpath(local_path)
-            # Replace path if mapping available
-            if server:
-                # Map local path to server path
-                if local_path in uri:
-                    uri = uri.replace(local_path, server_path)
-                    break
-            else:
-                # Map server path to local path
-                if server_path in uri:
-                    uri = uri.replace(server_path, local_path)
-                    break
+    if isinstance(path_mapping, list):
+        mapped_paths.extend(path_mapping)
+    elif isinstance(path_mapping, dict):
+        mapped_paths.extend(path_mapping.items())
+    # Go through path mappings
+    for server_path, local_path in mapped_paths:
+        server_path = os.path.normpath(server_path)
+        local_path = os.path.normpath(local_path)
+        # Replace path if mapping available
+        if server:
+            # Map local path to server path
+            if local_path in uri:
+                uri = uri.replace(local_path, server_path)
+                break
+        else:
+            # Map server path to local path
+            if server_path in uri:
+                uri = uri.replace(server_path, local_path)
+                break
     else:
         sublime.set_timeout(lambda: sublime.status_message('Xdebug: No path mapping defined, returning given path.'), 100)
 


### PR DESCRIPTION
Implemented better mappings from "mrphang" repo so you can specify your folders in particular order via list (instead of dict) as such:
"path_mapping":
[
  ["/path/1/on/remote", "/path/1/on/local"],
  ["/path/2/on/remote", "/path/2/on/local"],
]

Also, fixed utf special character in array keys. This error has been suppressed:
Length mismatch encountered while reading the Xdebug message