### PR TITLE
add option to allow omitting $this from context

### DIFF
--- a/Xdebug.sublime-settings
+++ b/Xdebug.sublime-settings
@@ -119,6 +119,9 @@
         "cells": [[0, 0, 2, 1], [0, 1, 1, 2], [1, 1, 2, 2]]
     },
 
+    // Omit $this from context view when debugging.
+    "omit_this": false,
+
     // Group and index positions for debug views.
     "breakpoint_group": 2,
     "breakpoint_index": 1,

--- a/xdebug/settings.py
+++ b/xdebug/settings.py
@@ -33,6 +33,8 @@ KEY_BROWSER_NO_EXECUTE = 'browser_no_execute'
 KEY_DISABLE_LAYOUT = 'disable_layout'
 KEY_DEBUG_LAYOUT = 'debug_layout'
 
+KEY_OMIT_THIS = 'omit_this'
+
 KEY_BREAKPOINT_GROUP = 'breakpoint_group'
 KEY_BREAKPOINT_INDEX = 'breakpoint_index'
 KEY_CONTEXT_GROUP = 'context_group'
@@ -116,6 +118,7 @@ CONFIG_KEYS = [
     KEY_BROWSER_NO_EXECUTE,
     KEY_DISABLE_LAYOUT,
     KEY_DEBUG_LAYOUT,
+    KEY_OMIT_THIS,
     KEY_BREAKPOINT_GROUP,
     KEY_BREAKPOINT_INDEX,
     KEY_CONTEXT_GROUP,

--- a/xdebug/view.py
+++ b/xdebug/view.py
@@ -102,6 +102,8 @@ def generate_context_output(context, indent=0):
     if not isinstance(context, dict):
         return values
     for variable in context.values():
+        if variable['name'] == '$this' and get_value(S.KEY_OMIT_THIS):
+            continue
         has_children = False
         property_text = ''
         # Set indentation


### PR DESCRIPTION
new option `omit_this` defaults to `false`
if set to `true` `$this` will be omitted from context